### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A Model Context Protocol (MCP) server that provides domain registration information and SSL certificate monitoring capabilities. Perfect for security monitoring, domain management, and certificate lifecycle tracking.
 
+<a href="https://glama.ai/mcp/servers/@firesh/sslmon-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@firesh/sslmon-mcp/badge" alt="SSL Monitor Server MCP server" />
+</a>
+
 ## 🚀 Quick Start
 
 ### NPX (Recommended)


### PR DESCRIPTION
This PR adds a badge for the [SSL Monitor MCP Server](https://glama.ai/mcp/servers/@firesh/sslmon-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@firesh/sslmon-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@firesh/sslmon-mcp/badge" alt="SSL Monitor Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.