### PR TITLE
fix: resolve TypeScript compilation error for cert CN field types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -421,8 +421,8 @@ export class SSLMonitorMCP {
           domain,
           validFrom: validFrom.toISOString(),
           validTo: validTo.toISOString(),
-          issuer: cert.issuer?.CN || 'Unknown',
-          subject: cert.subject?.CN || domain,
+          issuer: (Array.isArray(cert.issuer?.CN) ? cert.issuer.CN[0] : cert.issuer?.CN) || 'Unknown',
+          subject: (Array.isArray(cert.subject?.CN) ? cert.subject.CN[0] : cert.subject?.CN) || domain,
           isValid,
           daysUntilExpiry,
         };


### PR DESCRIPTION
cert.issuer.CN and cert.subject.CN are typed as string | string[] in
Node.js TLS module, but SSLInfo interface requires string. Handle both
cases by extracting the first element when the value is an array.

https://claude.ai/code/session_01Sbrx5ccFKkNCoS3LTgHi4Q